### PR TITLE
Docker + frontend default proxy-service changes

### DIFF
--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -59,11 +59,8 @@ services:
       - predictions:/data/prankweb
 volumes:
   rabbitmq:
-    external: True
     name: prankweb_rabbitmq
   conservation:
-    external: True
     name: prankweb_conservation
   predictions:
-    external: True
     name: prankweb_predictions

--- a/executor/Dockerfile
+++ b/executor/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update \
 
 WORKDIR /opt/alignment-based-conservation-dependencies
 
-RUN wget ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-x64-linux.tar.gz -q \
+RUN wget https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.9.0/ncbi-blast-2.9.0+-x64-linux.tar.gz -q \
  && ls -l . \
  && tar -xzf ncbi-blast-2.9.0+-x64-linux.tar.gz \
  && rm ./ncbi-blast-2.9.0+-x64-linux.tar.gz

--- a/frontend/server/configuration.js
+++ b/frontend/server/configuration.js
@@ -6,6 +6,6 @@ module.exports = {
   // frontend without the need to run another component.
   //"proxy-directory": "../../data/database/",
   // Use the option bellow to proxy commands to task runner instance.
-  // This allows you to run tasks or connect to existing instance (p2rank.cz).
+  // This allows you to run tasks or connect to existing instance (https://prankweb.cz).
   "proxy-service": "127.0.0.1:5000",
 }

--- a/frontend/server/configuration.js
+++ b/frontend/server/configuration.js
@@ -7,5 +7,5 @@ module.exports = {
   //"proxy-directory": "../../data/database/",
   // Use the option bellow to proxy commands to task runner instance.
   // This allows you to run tasks or connect to existing instance (https://prankweb.cz).
-  "proxy-service": "127.0.0.1:5000",
+  "proxy-service": "https://prankweb.cz",
 }


### PR DESCRIPTION
Removed `external` from the `docker-compose-develop.yml` file as the user would need to create the volume themselves anyway.
Fixed executor/Dockerfile URL for Blast.
Changed default `proxy-service` to the running PrankWeb instance in frontend configuration.