### PR TITLE
Removed black from pocket colors

### DIFF
--- a/frontend/client/custom-types.ts
+++ b/frontend/client/custom-types.ts
@@ -196,7 +196,6 @@ export const AlphaFoldColorsMolStar = [
  * Colorblind edited scheme 'Wong' from https://davidmathlogic.com/colorblind/ 
  */
 export const DefaultPocketColors = [
-    "000000",
     "CE0000",
     "F0E442",
     "E69F00",


### PR DESCRIPTION
Removes black from the default pocket colors, so the structure is more visible.