### PR TITLE
Conservation preparation fix

### DIFF
--- a/frontend/client/viewer/molstar-visualise.ts
+++ b/frontend/client/viewer/molstar-visualise.ts
@@ -829,7 +829,7 @@ function getSurfaceAtomSelection(plugin: PluginUIContext, ids: string[]) {
  */
 function getSelectionFromChainAuthId(plugin: PluginUIContext, chainId: string, positions: number[]) {
     const query = MS.struct.generator.atomGroups({
-        'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.label_asym_id(), chainId]),
+        'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.auth_asym_id(), chainId]),
         'residue-test': MS.core.set.has([MS.set(...positions), MS.struct.atomProperty.macromolecular.auth_seq_id()]),
         'group-by': MS.struct.atomProperty.macromolecular.residueKey()
     });
@@ -921,7 +921,7 @@ export function getConfidentResiduesFromPrediction(prediction: PredictionData) {
         }
 
         const query = MS.struct.generator.atomGroups({
-            'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.label_asym_id(), chain]),
+            'chain-test': MS.core.rel.eq([MS.struct.atomProperty.macromolecular.auth_asym_id(), chain]),
             'residue-test': MS.core.set.has([MS.set(...newPositions), MS.struct.atomProperty.macromolecular.auth_seq_id()]),
             'group-by': MS.struct.atomProperty.macromolecular.residueKey()
         });


### PR DESCRIPTION
This is my attempt to fix the `prepare_conservation` method.

The way I made it work is that we drop all `X` residue scores (and it also makes sense that those residues probably wouldn't be conserved anyway). Then, I have fixed the sequence indexing which would yield wrong results when a chain contains a non-standard AA. Later, when comparing the sequence and scores lengths, I have decided for the following checks:

1. `len(sequence) > len(scores_arr)` - there still exists at least one non-standard AA (which is **not denoted by X**). Then, the for loop inserts a zero conservation score for these AAs. This information is logged.
2. `len(sequence) < len(scores_arr)` - we do not have the information about some residues. This is simply wrong because then we are not able to find the correct mapping and something went wrong. Still raises an error.
3. `len(sequence) == len(scores_arr)` - expected, ideal behavior for most cases (happens most of the times even with `X` AAs present).

Also, I have noticed that we were not using author IDs for chains which caused inconsistency between the 1D and 3D viewer synchronization, so I have fixed that straight away as well.

Tested out with the problematic structures #139 , #137 , both working for me. So merging this might resolve these issues.